### PR TITLE
Cleanups, refactors, and bug fixes

### DIFF
--- a/nt_extras.py
+++ b/nt_extras.py
@@ -41,56 +41,47 @@ def replace_dtype_labels(string):
 
 
 def gen_subnodes(a, b, setting1, setting2):
-    return [
+    output = [
         [
-            " {} {} {}".format(a, d[0], d[1]),
-            "{} {} ({}{}) {}".format(
-                str.title(replace_dtype_labels(d[0])),
-                str.title(d[1]).replace("_", ""),
-                d[0].replace("FLOAT_", "")[0],
-                d[1][0],
-                b,
-            ),
-        ]
-        for d in itertools.product(setting1, setting2)
-    ]
+            f' {a} {d0} {d1}',
+            f'{str.title(replace_dtype_labels(d0))} {str.title(d1).replace("_", "")} ({d0.replace("FLOAT_", "")[0]}{d1[0]}) {b}'
+        ] 
+        for d0, d1 in itertools.product(setting1, setting2)]
+    #print(output)
+    return output
 
 
 def gen_dtype_subnodes(a, b):
-    return [
+    output = [
         [
-            " {} {}".format(a, d),
-            "{} ({}) {}".format(
-                str.title(replace_dtype_labels(d)),
-                d[0],
-                b,
-            ),
+            f' {a} {d}',
+            f'{str.title(replace_dtype_labels(d))} ({d[0]}) {b}'
         ]
         for d in DATA_TYPE
     ]
+    #print(output)
+    return output
 
 
 def gen_non_dtype_subnodes(a, b, setting1):
-    return [
+    output = [
         [
-            " {} {}".format(a, d),
-            "{} ({}) {}".format(str.title(d).replace("_", " "), d[0], b),
+            f' {a} {d}',
+            f'{str.title(d).replace("_", " ")} ({d[0]}) {b}',
         ]
         for d in setting1
     ]
+    #print(output)
+    return output
 
 
 def gn_cmp_str_col(a, setting1, setting2):
     return [
         [
-            f" CMP {a} {d[1]}",
-            "{} {} (C{}) COMP".format(
-                str.title(d[0]),
-                str.title(d[1].replace("_", " ")),
-                d[0][0] + d[1][0],
-            ),
+            f' CMP {a} {d1}',
+            f'{str.title(d0)} {str.title(d1.replace("_", " "))} (C{d0[0] + d1[0]}) COMP'
         ]
-        for d in itertools.product(setting1, setting2)
+        for d0, d1 in itertools.product(setting1, setting2)
     ]
 
 
@@ -104,40 +95,25 @@ gn_cmp_col = gn_cmp_str_col("RGBA", ["COLOR"], GN_CMP_OPS[4:])
 
 gn_cmp_fl_it = [
     [
-        f" CMP {d[0]} {d[1]}",
-        "{} {} (C{}{}) COMP".format(
-            str.title(replace_dtype_labels((d[0]))),
-            str.title(d[1]).replace("_", " "),
-            d[0][0],
-            op_abbr(d[1]),
-        ),
+        f' CMP {d0} {d1}',
+        f'{str.title(replace_dtype_labels((d0)))} {str.title(d1).replace("_", " ")} (C{d0[0] + op_abbr(d1)}) COMP'
     ]
-    for d in itertools.product(["FLOAT", "INT"], GN_CMP_OPS[:-2])
+    for d0, d1 in itertools.product(["FLOAT", "INT"], GN_CMP_OPS[:-2])
 ]
 
 gn_cmp_vec = [
     [
-        f" CMP VECTOR {d[0]} {d[1]}",
-        "V {} {} (CV{}{}) COMP".format(
-            str.title(d[0]).replace("_", " ").replace(" Product", ""),
-            str.title(d[1]).replace("_", " "),
-            d[0][0],
-            op_abbr(d[1]),
-        ),
+        f' CMP VECTOR {d0} {d1}',
+        f'V {str.title(d0).replace("_", " ").replace(" Product", "")} {str.title(d1).replace("_", " ")} (CV{d0[0] + op_abbr(d1)}) COMP'
     ]
-    for d in itertools.product(GN_CMP_VEC_MODES, GN_CMP_OPS[:-2])
+    for d0, d1 in itertools.product(GN_CMP_VEC_MODES, GN_CMP_OPS[:-2])
 ]
 
 
 c_filter = [
     [
-        f" F {ft.replace('DIAMOND', 'SHARPEN_DIAMOND').replace('BOX','SHARPEN')}",
-        "{} ({}) FILTER".format(
-            str.title(
-                ft.replace("DIAMOND", "Diamond Sharpen").replace("BOX", "Box Sharpen")
-            ),
-            ft[0],
-        ),
+        f' F {ft.replace("DIAMOND", "SHARPEN_DIAMOND").replace("BOX","SHARPEN")}',
+        f'{str.title(ft.replace("DIAMOND", "Diamond Sharpen").replace("BOX", "Box Sharpen"))} ({ft[0]}) FILTER'
     ]
     for ft in FILTER_MODES
 ]

--- a/nt_extras.py
+++ b/nt_extras.py
@@ -47,7 +47,6 @@ def gen_subnodes(a, b, setting1, setting2):
             f'{str.title(replace_dtype_labels(d0))} {str.title(d1).replace("_", "")} ({d0.replace("FLOAT_", "")[0]}{d1[0]}) {b}'
         ] 
         for d0, d1 in itertools.product(setting1, setting2)]
-    #print(output)
     return output
 
 
@@ -59,7 +58,6 @@ def gen_dtype_subnodes(a, b):
         ]
         for d in DATA_TYPE
     ]
-    #print(output)
     return output
 
 
@@ -71,7 +69,6 @@ def gen_non_dtype_subnodes(a, b, setting1):
         ]
         for d in setting1
     ]
-    #print(output)
     return output
 
 

--- a/nt_extras.py
+++ b/nt_extras.py
@@ -43,7 +43,7 @@ def replace_dtype_labels(string):
 def gen_subnodes(a, b, setting1, setting2):
     output = [
         [
-            f' {a} {d0} {d1}',
+            f'{a} {d0} {d1}',
             f'{str.title(replace_dtype_labels(d0))} {str.title(d1).replace("_", "")} ({d0.replace("FLOAT_", "")[0]}{d1[0]}) {b}'
         ] 
         for d0, d1 in itertools.product(setting1, setting2)]
@@ -53,7 +53,7 @@ def gen_subnodes(a, b, setting1, setting2):
 def gen_dtype_subnodes(a, b):
     output = [
         [
-            f' {a} {d}',
+            f'{a} {d}',
             f'{str.title(replace_dtype_labels(d))} ({d[0]}) {b}'
         ]
         for d in DATA_TYPE
@@ -64,7 +64,7 @@ def gen_dtype_subnodes(a, b):
 def gen_non_dtype_subnodes(a, b, setting1):
     output = [
         [
-            f' {a} {d}',
+            f'{a} {d}',
             f'{str.title(d).replace("_", " ")} ({d[0]}) {b}',
         ]
         for d in setting1
@@ -75,7 +75,7 @@ def gen_non_dtype_subnodes(a, b, setting1):
 def gn_cmp_str_col(a, setting1, setting2):
     return [
         [
-            f' CMP {a} {d1}',
+            f'CMP {a} {d1}',
             f'{str.title(d0)} {str.title(d1.replace("_", " "))} (C{d0[0] + d1[0]}) COMP'
         ]
         for d0, d1 in itertools.product(setting1, setting2)
@@ -92,7 +92,7 @@ gn_cmp_col = gn_cmp_str_col("RGBA", ["COLOR"], GN_CMP_OPS[4:])
 
 gn_cmp_fl_it = [
     [
-        f' CMP {d0} {d1}',
+        f'CMP {d0} {d1}',
         f'{str.title(replace_dtype_labels((d0)))} {str.title(d1).replace("_", " ")} (C{d0[0] + op_abbr(d1)}) COMP'
     ]
     for d0, d1 in itertools.product(["FLOAT", "INT"], GN_CMP_OPS[:-2])
@@ -100,7 +100,7 @@ gn_cmp_fl_it = [
 
 gn_cmp_vec = [
     [
-        f' CMP VECTOR {d0} {d1}',
+        f'CMP VECTOR {d0} {d1}',
         f'V {str.title(d0).replace("_", " ").replace(" Product", "")} {str.title(d1).replace("_", " ")} (CV{d0[0] + op_abbr(d1)}) COMP'
     ]
     for d0, d1 in itertools.product(GN_CMP_VEC_MODES, GN_CMP_OPS[:-2])
@@ -109,7 +109,7 @@ gn_cmp_vec = [
 
 c_filter = [
     [
-        f' F {ft.replace("DIAMOND", "SHARPEN_DIAMOND").replace("BOX","SHARPEN")}',
+        f'F {ft.replace("DIAMOND", "SHARPEN_DIAMOND").replace("BOX","SHARPEN")}',
         f'{str.title(ft.replace("DIAMOND", "Diamond Sharpen").replace("BOX", "Box Sharpen"))} ({ft[0]}) FILTER'
     ]
     for ft in FILTER_MODES

--- a/operators.py
+++ b/operators.py
@@ -14,7 +14,6 @@ from bpy.props import EnumProperty, StringProperty
 
 ADD_ON_PATH = pathlib.PurePath(os.path.dirname(__file__)).name
 
-
 def nt_debug(msg):
     prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
@@ -57,13 +56,13 @@ def sub_search(
     enum_items, node_type_index, node_type, extras_ops, index_offset, tally_dict
 ):
     if node_type_index > -1:
-        nt_debug(f"Adding ${str.lower(node_type)} nodes")
+        nt_debug(f'Adding ${node_type} nodes')
         for index2, subname in enumerate(extras_ops):
             sn_name, sn_label = subname
             tally = tally_dict.get(sn_label, {"tally":0})["tally"]
             enum_items.append(
                 (
-                    f"{node_type_index} {sn_name} {sn_label}",
+                    f'{node_type_index} {sn_name} {sn_label}',
                     sn_label,
                     str(tally),
                     index_offset + index2 + 1,
@@ -153,7 +152,7 @@ class NODE_OT_add_tabber_search(Operator):
     def find_node_item(self, context):
         nt_debug("DEF: find_node_item")
         tmp = int(self.node_item.split()[0])
-        nt_debug("FIND_NODE_ITEM: Tmp : " + str(self.node_item.split()))
+        nt_debug(f'FIND_NODE_ITEM: Tmp : {str(self.node_item.split())}')
 
         node_item = tmp
         extra = self.node_item.split()[1:]
@@ -179,13 +178,13 @@ class NODE_OT_add_tabber_search(Operator):
         # Add to tally
         short = ""
         words = item.label.split()
-        nt_debug("EXECUTE: Item label : " + str(item.label))
+        nt_debug(f'EXECUTE: Item label : {str(item.label)}')
         for word in words:
             short += word[0]
-        match = item.label + " (" + short + ")"
+        match = f'{item.label} ({short})'
 
         type = self.node_item.split()[1]
-        nt_debug("Checking type : " + str(type))
+        nt_debug(f'Checking type : str(type)')
 
         if type == "0":
             nt_debug("Writing normal node tally")
@@ -206,8 +205,8 @@ class NODE_OT_add_tabber_search(Operator):
             self.create_node(context, item.nodetype, node_tree_type)
 
             nt_debug(str(item.nodetype))
-            nt_debug("extra 0: " + str(extra[0]))
-            nt_debug("extra 1: " + str(extra[1]))
+            nt_debug(f'extra 0: {str(extra[0])}')
+            nt_debug(f'extra 1: {str(extra[1])}')
 
             space = context.space_data
             node_active = context.active_node

--- a/operators.py
+++ b/operators.py
@@ -29,8 +29,8 @@ def take_fifth(elem):
 
 
 def write_score(category, enum_items):
+    print(category)
     prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
-
     if category == "S":
         category = "shader.json"
     if category == "C":
@@ -273,7 +273,8 @@ class NODE_OT_add_tabber_search(Operator):
 
             # Mix Color
             if key == "C":
-                node_active.data_type = "RGBA"
+                if space.tree_type != "CompositorNodeTree":
+                    node_active.data_type = "RGBA"
                 node_active.blend_type = extra[1]
 
             # Named Attribute

--- a/operators.py
+++ b/operators.py
@@ -28,17 +28,10 @@ def take_fifth(elem):
     return int(elem[2])
 
 
-def write_score(category, enum_items):
-    print(category)
+def write_score(enum_items):
+    tree_type = bpy.context.space_data.tree_type
+    category = f'{tree_type.removesuffix("NodeTree").lower()}.json'
     prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
-    if category == "S":
-        category = "shader.json"
-    if category == "C":
-        category = "compositor.json"
-    if category == "T":
-        category = "texture.json"
-    if category == "G":
-        category = "geometry.json"
 
     path = os.path.dirname(__file__) + "/" + category
     if not os.path.exists(path):
@@ -154,7 +147,7 @@ class NODE_OT_add_tabber_search(Operator):
                 index_offset = index
 
                 item_index[item.label] = index
-
+                
         # Add sub node searching if enabled
         if prefs.sub_search:
             si = [item_index[i] for i in item_index]
@@ -218,10 +211,10 @@ class NODE_OT_add_tabber_search(Operator):
 
         if type == "0":
             nt_debug("Writing normal node tally")
-            write_score(item.nodetype[0], match)
+            write_score(match)
         else:
             nt_debug("Writing sub node tally")
-            write_score(item.nodetype[0], nice_name)
+            write_score(nice_name)
 
         nt_debug("Hack")
 

--- a/operators.py
+++ b/operators.py
@@ -35,11 +35,8 @@ def write_score(enum_items):
 
     path = os.path.dirname(__file__) + "/" + category
     if not os.path.exists(path):
-        content = {}
-        content[enum_items] = {"tally": 1}
-
         with open(path, "w") as f:
-            json.dump(content, f)
+            json.dump({enum_items: {"tally": 1}}, f)
 
         print("Nodetabber created :" + path)
     else:

--- a/operators.py
+++ b/operators.py
@@ -1,28 +1,16 @@
 import bpy
 import json
-
+import os
+import pathlib
 import time
-
-import nodeitems_utils
-import pprint
 
 from .gn_items import geonodes_node_items
 from . import nt_extras
 
-import os
-import pathlib
+import nodeitems_utils
+from bpy.types import Operator, PropertyGroup
+from bpy.props import EnumProperty, StringProperty
 
-from bpy.types import (
-    Operator,
-    PropertyGroup,
-)
-from bpy.props import (
-    BoolProperty,
-    CollectionProperty,
-    EnumProperty,
-    IntProperty,
-    StringProperty,
-)
 
 ADD_ON_PATH = pathlib.PurePath(os.path.dirname(__file__)).name
 
@@ -108,7 +96,7 @@ class NodeTabSetting(PropertyGroup):
     )
 
 
-class NODE_OT_add_tabber_search(bpy.types.Operator):
+class NODE_OT_add_tabber_search(Operator):
     """Add a node to the active tree using node tabber"""
 
     bl_idname = "node.add_tabber_search"
@@ -427,7 +415,7 @@ class NODE_OT_add_tabber_search(bpy.types.Operator):
     )
 
 
-class NODE_OT_reset_tally(bpy.types.Operator):
+class NODE_OT_reset_tally(Operator):
     """Reset the tally count"""
 
     bl_idname = "node.reset_tally"

--- a/operators.py
+++ b/operators.py
@@ -61,15 +61,16 @@ def sub_search(
     if node_type_index > -1:
         nt_debug(f"Adding ${str.lower(node_type)} nodes")
         for index2, subname in enumerate(extras_ops):
+            sn_name, sn_label = subname
             tally = 0
-            if subname[1] in content:
-                tally = content[subname[1]]["tally"]
+            if sn_label in content:
+                tally = content[sn_label]["tally"]
             enum_items.append(
                 (
-                    str(node_type_index) + subname[0] + " " + subname[1],
-                    subname[1],
+                    f"{node_type_index} {sn_name} {sn_label}",
+                    sn_label,
                     str(tally),
-                    index_offset + 1 + index2,
+                    index_offset + index2 + 1,
                 )
             )
         index_offset += index2 + 1

--- a/operators.py
+++ b/operators.py
@@ -43,11 +43,9 @@ def write_score(enum_items):
         with open(path, "r") as f:
             tally_dict = json.load(f)
 
-        if enum_items in tally_dict:
-            if tally_dict[enum_items]["tally"] < prefs.tally_weight:
-                tally_dict[enum_items]["tally"] += 1
-        else:
-            tally_dict[enum_items] = {"tally": 1}
+        old_tally = tally_dict.get(enum_items, {"tally":0})["tally"]
+        new_tally = min(old_tally + 1, prefs.tally_weight)
+        tally_dict[enum_items] = {"tally": new_tally}
 
         with open(path, "w") as f:
             json.dump(tally_dict, f)

--- a/operators.py
+++ b/operators.py
@@ -125,25 +125,12 @@ class NODE_OT_add_tabber_search(Operator):
 
         for index, item in enumerate(node_items):
             if isinstance(item, nodeitems_utils.NodeItem):
-                short = ""
-                tally = 0
-                words = item.label.split()
-                for word in words:
-                    short += word[0]
-                match = item.label + " (" + short + ")"
-                if match in content:
-                    tally = content[match]["tally"]
+                abbr = "".join(word[0] for word in item.label.split())
+                match = f'{item.label} ({abbr})'
+                tally = content.get(match, {"tally":0})["tally"]
 
-                enum_items.append(
-                    (
-                        str(index) + " 0 0",
-                        item.label + " (" + short + ")",
-                        str(tally),
-                        index,
-                    )
-                )
+                enum_items.append((f'{index} 0 0', match, str(tally), index,))
                 index_offset = index
-
                 item_index[item.label] = index
                 
         # Add sub node searching if enabled

--- a/operators.py
+++ b/operators.py
@@ -148,19 +148,18 @@ class NODE_OT_add_tabber_search(Operator):
     # Look up the item based on index
     def find_node_item(self, context):
         nt_debug("DEF: find_node_item")
-        tmp = int(self.node_item.split()[0])
         nt_debug(f'FIND_NODE_ITEM: Tmp : {str(self.node_item.split())}')
 
-        node_item = tmp
-        extra = self.node_item.split()[1:]
-        nice_name = " ".join(self.node_item.split()[3:])
-        node_items = nodeitems_utils.node_items_iter(context)
+        data = self.node_item.split()
+        node_index, extra, nice_name = int(data[0]), data[1:], " ".join(data[3:])
 
         if context.space_data.tree_type == "GeometryNodeTree":
             node_items = geonodes_node_items(context)
+        else:
+            node_items = nodeitems_utils.node_items_iter(context)
 
         for index, item in enumerate(node_items):
-            if index == node_item:
+            if index == node_index:
                 return [item, extra, nice_name]
         return None
 
@@ -181,7 +180,7 @@ class NODE_OT_add_tabber_search(Operator):
         match = f'{item.label} ({short})'
 
         type = self.node_item.split()[1]
-        nt_debug(f'Checking type : str(type)')
+        nt_debug(f'Checking type : {str(type)}')
 
         if type == "0":
             nt_debug("Writing normal node tally")

--- a/operators.py
+++ b/operators.py
@@ -413,12 +413,11 @@ class NODE_OT_reset_tally(Operator):
                 # delete file
                 os.remove(path)
 
-            if reset:
-                info = "Reset Tallies"
-                self.report({"INFO"}, info)
-            else:
-                info = "No tallies to reset."
-                self.report({"INFO"}, info)
+        if reset:
+            info = "Reset Tallies"
+        else:
+            info = "No tallies to reset."
+        self.report({"INFO"}, info)
 
         return {"FINISHED"}
 

--- a/operators.py
+++ b/operators.py
@@ -23,7 +23,7 @@ def nt_debug(msg):
     return
 
 
-def take_fifth(elem):
+def sort_by_tally(elem):
     return int(elem[2])
 
 
@@ -138,7 +138,7 @@ class NODE_OT_add_tabber_search(Operator):
                     )
 
         if prefs.tally:
-            enum_items.sort(key=take_fifth, reverse=True)
+            enum_items.sort(key=sort_by_tally, reverse=True)
 
         return enum_items
 

--- a/operators.py
+++ b/operators.py
@@ -354,12 +354,10 @@ class NODE_OT_add_tabber_search(Operator):
         context.window_manager.invoke_search_popup(self)
         return {"CANCELLED"}
 
-    populate = node_enum_items
-
     node_item: EnumProperty(
         name="Node Type",
         description="Node type",
-        items=populate,
+        items=node_enum_items,
     )
 
 

--- a/operators.py
+++ b/operators.py
@@ -389,13 +389,12 @@ class NODE_OT_reset_tally(Operator):
         return {"FINISHED"}
 
 
+classes = (NodeTabSetting, NODE_OT_add_tabber_search, NODE_OT_reset_tally)
+
 def register():
-    bpy.utils.register_class(NodeTabSetting)
-    bpy.utils.register_class(NODE_OT_add_tabber_search)
-    bpy.utils.register_class(NODE_OT_reset_tally)
-
-
+    for cls in classes:
+        bpy.utils.register_class(cls)
+    
 def unregister():
-    bpy.utils.unregister_class(NodeTabSetting)
-    bpy.utils.unregister_class(NODE_OT_add_tabber_search)
-    bpy.utils.unregister_class(NODE_OT_reset_tally)
+    for cls in classes:
+        bpy.utils.unregister_class(cls)

--- a/operators.py
+++ b/operators.py
@@ -16,7 +16,7 @@ ADD_ON_PATH = pathlib.PurePath(os.path.dirname(__file__)).name
 
 def nt_debug(msg):
     prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
-
+    
     if prefs.nt_debug:
         print(str(msg))
 
@@ -172,17 +172,14 @@ class NODE_OT_add_tabber_search(Operator):
         item, extra, nice_name = self.find_node_item(context)
 
         # Add to tally
-        short = ""
-        words = item.label.split()
         nt_debug(f'EXECUTE: Item label : {str(item.label)}')
-        for word in words:
-            short += word[0]
-        match = f'{item.label} ({short})'
+        subnodes_id = self.node_item.split()[1]
+        nt_debug(f'Checking type : {str(subnodes_id)}')
 
-        type = self.node_item.split()[1]
-        nt_debug(f'Checking type : {str(type)}')
+        if subnodes_id == "0":
+            abbr = "".join(word[0] for word in item.label.split())
+            match = f'{item.label} ({abbr})'
 
-        if type == "0":
             nt_debug("Writing normal node tally")
             write_score(match)
         else:

--- a/operators.py
+++ b/operators.py
@@ -55,21 +55,20 @@ def write_score(enum_items):
 def sub_search(
     enum_items, node_type_index, node_type, extras_ops, index_offset, tally_dict
 ):
-    if node_type_index > -1:
-        nt_debug(f'Adding ${node_type} nodes')
-        for index2, subname in enumerate(extras_ops):
-            sn_name, sn_label = subname
-            tally = tally_dict.get(sn_label, {"tally":0})["tally"]
-            enum_items.append(
-                (
-                    f'{node_type_index} {sn_name} {sn_label}',
-                    sn_label,
-                    str(tally),
-                    index_offset + index2 + 1,
-                )
+    nt_debug(f'Adding ${node_type} nodes')
+    for index2, subname in enumerate(extras_ops):
+        sn_name, sn_label = subname
+        tally = tally_dict.get(sn_label, {"tally":0})["tally"]
+        enum_items.append(
+            (
+                f'{node_type_index} {sn_name} {sn_label}',
+                sn_label,
+                str(tally),
+                index_offset + index2 + 1,
             )
-        index_offset += index2 + 1
-    return enum_items, index_offset
+        )
+    index_offset += index2 + 1
+    return index_offset
 
 
 class NodeTabSetting(PropertyGroup):
@@ -112,11 +111,8 @@ class NODE_OT_add_tabber_search(Operator):
             with open(path, "r") as f:
                 tally_dict = json.load(f)
 
-        index_offset = 0
-
-        item_index = {}
-        for key in nt_extras.SUBNODE_ENTRIES:
-            item_index[key] = -1
+        index_offset = 0               
+        item_index = {key: -1 for key in nt_extras.SUBNODE_ENTRIES}
 
         for index, item in enumerate(node_items):
             if isinstance(item, nodeitems_utils.NodeItem):
@@ -133,12 +129,13 @@ class NODE_OT_add_tabber_search(Operator):
             sn_entries = nt_extras.SUBNODE_ENTRIES
             sn_info = zip(sn_entries.keys(), item_index.values(), item_index.keys(), sn_entries.values())
 
-            for nodetype, *sn_data in sn_info:
+            for nodetype, index, *sn_data in sn_info:
                 if space == "CompositorNodeTree" and nodetype == "Map Range":
                     continue
-                enum_items, index_offset = sub_search(
-                    enum_items, *sn_data, index_offset, tally_dict
-                )
+                if index > -1:
+                    index_offset = sub_search(
+                        enum_items, index, *sn_data, index_offset, tally_dict
+                    )
 
         if prefs.tally:
             enum_items.sort(key=take_fifth, reverse=True)

--- a/operators.py
+++ b/operators.py
@@ -112,20 +112,13 @@ class NODE_OT_add_tabber_search(Operator):
         prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
         enum_items.clear()
-        category = ""
         space = context.space_data.tree_type
 
-        node_items = nodeitems_utils.node_items_iter(context)
-
-        if space[0] == "S":
-            category = "shader.json"
-        if space[0] == "C":
-            category = "compositor.json"
-        if space[0] == "T":
-            category = "texture.json"
-        if space[0] == "G":
+        category = f'{space.removesuffix("NodeTree").lower()}.json'
+        if space == "GeometryNodeTree":
             node_items = geonodes_node_items(context)
-            category = "geometry.json"
+        else:
+            node_items = nodeitems_utils.node_items_iter(context)
 
         path = os.path.dirname(__file__) + "/" + category
         if not os.path.exists(path):

--- a/operators.py
+++ b/operators.py
@@ -141,12 +141,9 @@ class NODE_OT_add_tabber_search(Operator):
                 )
 
         if prefs.tally:
-            tmp = enum_items
-            tmp = sorted(enum_items, key=take_fifth, reverse=True)
-        else:
-            tmp = enum_items
-        return tmp
-        # return enum_items
+            enum_items.sort(key=take_fifth, reverse=True)
+
+        return enum_items
 
     # Look up the item based on index
     def find_node_item(self, context):

--- a/operators.py
+++ b/operators.py
@@ -205,15 +205,6 @@ class NODE_OT_add_tabber_search(Operator):
             node_tree_type = None
             if "node_tree" in item.settings:
                 node_tree_type = eval(item.settings["node_tree"])
-            try:
-                for setting in item.settings.items():
-                    if setting[0] != "node_tree":
-                        ops = self.settings.add()
-                        ops.name = setting[0]
-                        ops.value = setting[1]
-            except AttributeError:
-                print("An exception occurred")
-
             self.create_node(context, item.nodetype, node_tree_type)
 
             nt_debug(str(item.nodetype))
@@ -221,9 +212,7 @@ class NODE_OT_add_tabber_search(Operator):
             nt_debug("extra 1: " + str(extra[1]))
 
             space = context.space_data
-            node_tree = space.node_tree
             node_active = context.active_node
-            node_selected = context.selected_nodes
 
             key = extra[0]
 

--- a/operators.py
+++ b/operators.py
@@ -115,10 +115,9 @@ class NODE_OT_add_tabber_search(Operator):
         space = context.space_data.tree_type
 
         category = f'{space.removesuffix("NodeTree").lower()}.json'
+        node_items = nodeitems_utils.node_items_iter(context)
         if space == "GeometryNodeTree":
             node_items = geonodes_node_items(context)
-        else:
-            node_items = nodeitems_utils.node_items_iter(context)
 
         path = os.path.dirname(__file__) + "/" + category
         if not os.path.exists(path):

--- a/operators.py
+++ b/operators.py
@@ -41,30 +41,28 @@ def write_score(enum_items):
         print("Nodetabber created :" + path)
     else:
         with open(path, "r") as f:
-            content = json.load(f)
+            tally_dict = json.load(f)
 
-        if enum_items in content:
-            if content[enum_items]["tally"] < prefs.tally_weight:
-                content[enum_items]["tally"] += 1
+        if enum_items in tally_dict:
+            if tally_dict[enum_items]["tally"] < prefs.tally_weight:
+                tally_dict[enum_items]["tally"] += 1
         else:
-            content[enum_items] = {"tally": 1}
+            tally_dict[enum_items] = {"tally": 1}
 
         with open(path, "w") as f:
-            json.dump(content, f)
+            json.dump(tally_dict, f)
 
     return
 
 
 def sub_search(
-    enum_items, node_type_index, node_type, extras_ops, index_offset, content
+    enum_items, node_type_index, node_type, extras_ops, index_offset, tally_dict
 ):
     if node_type_index > -1:
         nt_debug(f"Adding ${str.lower(node_type)} nodes")
         for index2, subname in enumerate(extras_ops):
             sn_name, sn_label = subname
-            tally = 0
-            if sn_label in content:
-                tally = content[sn_label]["tally"]
+            tally = tally_dict.get(sn_label, {"tally":0})["tally"]
             enum_items.append(
                 (
                     f"{node_type_index} {sn_name} {sn_label}",
@@ -112,10 +110,10 @@ class NODE_OT_add_tabber_search(Operator):
 
         path = os.path.dirname(__file__) + "/" + category
         if not os.path.exists(path):
-            content = {}
+            tally_dict = {}
         else:
             with open(path, "r") as f:
-                content = json.load(f)
+                tally_dict = json.load(f)
 
         index_offset = 0
 
@@ -127,7 +125,7 @@ class NODE_OT_add_tabber_search(Operator):
             if isinstance(item, nodeitems_utils.NodeItem):
                 abbr = "".join(word[0] for word in item.label.split())
                 match = f'{item.label} ({abbr})'
-                tally = content.get(match, {"tally":0})["tally"]
+                tally = tally_dict.get(match, {"tally":0})["tally"]
 
                 enum_items.append((f'{index} 0 0', match, str(tally), index,))
                 index_offset = index
@@ -142,7 +140,7 @@ class NODE_OT_add_tabber_search(Operator):
                 if space == "CompositorNodeTree" and nodetype == "Map Range":
                     continue
                 enum_items, index_offset = sub_search(
-                    enum_items, *sn_data, index_offset, content
+                    enum_items, *sn_data, index_offset, tally_dict
                 )
 
         if prefs.tally:

--- a/operators.py
+++ b/operators.py
@@ -16,8 +16,7 @@ ADD_ON_PATH = pathlib.PurePath(os.path.dirname(__file__)).name
 
 
 def nt_debug(msg):
-    addon = bpy.context.preferences.addons[ADD_ON_PATH]
-    prefs = addon.preferences
+    prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
     if prefs.nt_debug:
         print(str(msg))
@@ -30,8 +29,7 @@ def take_fifth(elem):
 
 
 def write_score(category, enum_items):
-    addon = bpy.context.preferences.addons[ADD_ON_PATH]
-    prefs = addon.preferences
+    prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
     if category == "S":
         category = "shader.json"
@@ -111,8 +109,7 @@ class NODE_OT_add_tabber_search(Operator):
         nt_debug("DEF: node_enum_items")
         enum_items = NODE_OT_add_tabber_search._enum_item_hack
 
-        addon = bpy.context.preferences.addons[ADD_ON_PATH]
-        prefs = addon.preferences
+        prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
         enum_items.clear()
         category = ""
@@ -209,8 +206,7 @@ class NODE_OT_add_tabber_search(Operator):
     def execute(self, context):
         nt_debug("DEF: execute")
         startTime = time.perf_counter()
-        addon = bpy.context.preferences.addons[ADD_ON_PATH]
-        prefs = addon.preferences
+        prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
         _find_node_item = self.find_node_item(context)
         item = _find_node_item[0]

--- a/operators.py
+++ b/operators.py
@@ -59,7 +59,7 @@ def sub_search(
     enum_items, node_type_index, node_type, extras_ops, index_offset, content
 ):
     if node_type_index > -1:
-        nt_debug(f"Adding ${node_type} nodes")
+        nt_debug(f"Adding ${str.lower(node_type)} nodes")
         for index2, subname in enumerate(extras_ops):
             tally = 0
             if subname[1] in content:
@@ -147,15 +147,14 @@ class NODE_OT_add_tabber_search(Operator):
                 
         # Add sub node searching if enabled
         if prefs.sub_search:
-            si = [item_index[i] for i in item_index]
-            sn = [str.lower(k) for k in item_index]
-            se = [nt_extras.SUBNODE_ENTRIES[e] for e in nt_extras.SUBNODE_ENTRIES]
-            nt = [t for t in nt_extras.SUBNODE_ENTRIES]
-            for s in zip(si, sn, se, nt):
-                if space[0] == "C" and s[3] == "Map Range":
+            sn_entries = nt_extras.SUBNODE_ENTRIES
+            sn_info = zip(sn_entries.keys(), item_index.values(), item_index.keys(), sn_entries.values())
+
+            for nodetype, *sn_data in sn_info:
+                if space == "CompositorNodeTree" and nodetype == "Map Range":
                     continue
                 enum_items, index_offset = sub_search(
-                    enum_items, s[0], s[1], s[2], index_offset, content
+                    enum_items, *sn_data, index_offset, content
                 )
 
         if prefs.tally:
@@ -190,10 +189,8 @@ class NODE_OT_add_tabber_search(Operator):
         startTime = time.perf_counter()
         prefs = bpy.context.preferences.addons[ADD_ON_PATH].preferences
 
-        _find_node_item = self.find_node_item(context)
-        item = _find_node_item[0]
-        extra = _find_node_item[1]
-        nice_name = _find_node_item[2]
+        #Fetch node item info
+        item, extra, nice_name = self.find_node_item(context)
 
         # Add to tally
         short = ""


### PR DESCRIPTION
Hi! These are sort of a collection of changes that didn't feel personally big enough to justify a PR for every one of them.
I apologize if having all of them bulked together makes it more of a pain to merge. If tinier but more frequent PRs are preferable, I'll be sure to do so in the future. 

As for the changes made:
Cleanup:
--- Renamed some of the variables to be more indicative of what they are doing.
--- Removed lines that didn't seem to be used anywhere in the code.
--- Folded addon prefs access into one line, as the `addon` variable doesn't seem to be used anywhere.

Refactors:
--- Used f-strings instead of str.format(), their syntax is similar but imo f-strings are more compact and readable
--- Used `dict.get()` instead of normal dictionary access, as you can specify a default return value for keys outside the dictionary, avoiding the more lengthy `if key in dict: value = dict[key], else: value = default` syntax.
--- Simplified the `if space[0] == S: category == shader.json, etc.` into `category = f'{space.removesuffix("NodeTree").lower()}.json'`

Bug fixes and behavior changes:
--- Changed the behavior of the tally writing to prevent a node getting "stuck" in their tally ranking when a user changes their preference for `tally_weight` to a lower value. Before, if a node has a tally higher than the current `tally_weight`, they just don't get updated. This to those nodes always ranking higher than other nodes no matter how many time you then use the other nodes. New behavior just updates any tallies higher than `tally_weight` to the value of `tally_weight`. 
_Note: (was going back and forth with just renaming tally_weight to tally_max in the future as that is more reflective of its behavior)_

--- Fixed the tally writing generating tally files named F and N, this stems from using `nodeitem.type` to determine which .json a tally is written to. Certain types don't start with `Shader`, `Geometry`, etc. and instead start with `Function` and `Node`, leading to the random F and N files being written. New behavior just looks at the current space a user is in (whether it's a `ShaderNodeTree`, `CompositorNodeTree`, etc.) to determine which .json file to write to which fully accounts all the different node types.

--- Mix Color Subnodes [Mix, Darken, Lighten, etc.], throws an error when called from the Compositor. This is because the Compositor doesn't have Mix Floats and Mix Vector, leading to the part of the addon code that sets the Mix data_type to throw an error as that attribute doesn't exist. New behavior just checks if the workspace is in Compositor and skips setting the data_type if that is the case.