### PR TITLE
Make Store Named Attribute subsearch consistent with abbreviation

### DIFF
--- a/nt_extras.py
+++ b/nt_extras.py
@@ -374,7 +374,7 @@ sample_nearest_surf = gen_dtype_subnodes("SNS", "SAMPLE NEAREST SURF")
 
 attr_stat = gen_subnodes("AST", "ATTR STAT", ["FLOAT", "FLOAT_VECTOR"], DOMAIN)
 raycast = gen_subnodes("RAY", "RAYCAST", DATA_TYPE, MAPPING)
-store_named_attr = gen_subnodes("STO", "STORE", DATA_TYPE, DOMAIN)
+store_named_attr = gen_subnodes("SNA", "STORE NAMED ATTR", DATA_TYPE, DOMAIN)
 capture_attr = gen_subnodes("CAP", "CAP ATTR", DATA_TYPE, DOMAIN)
 interpolate_dom = gen_subnodes("INTER", "INTERPOLATE DOM", DATA_TYPE, DOMAIN)
 sample_index = gen_subnodes("SIN", "SAMPLE INDEX", DATA_TYPE, DOMAIN)

--- a/operators.py
+++ b/operators.py
@@ -249,7 +249,7 @@ class NODE_OT_add_tabber_search(Operator):
                 node_active.domain = extra[2].replace("SPLINE", "CURVE")
 
             # Store Named Attribute
-            if key == "STO":
+            if key == "SNA":
                 node_active.data_type = extra[1].replace("FLOAT_COLOR", "BYTE_COLOR")
                 node_active.domain = extra[2].replace("SPLINE", "CURVE")
 


### PR DESCRIPTION
Currently, the subsearch entries for Store Named Attribute do not appear when you either: 
a.) Search for Store Named Attribute's abbreviation (SNA) instead of the subnodes' which is currently (STO)
b.) Put "Named Attr" in your search entry since the subnode entries only have "STORE" in their labels.

In my opinion, it's a bit more sensible for the subsearch entries to have the same abbreviation as the main search entry.