### PR TITLE
3.6 Changes (Index of Nearest and Simulation  Zone)

### DIFF
--- a/gn_items.py
+++ b/gn_items.py
@@ -150,6 +150,7 @@ def geonodes_node_items(context):
         NodeItem("GeometryNodeFieldOnDomain"),
         NodeItem("GeometryNodeSwitch"),
         NodeItem("GeometryNodeUVPackIslands"),
+        NodeItem("GeometryNodeIndexOfNearest"),
         NodeItem("GeometryNodeUVUnwrap"),
         NodeItem("GeometryNodeVolumeCube"),
         NodeItem("GeometryNodeVolumeToMesh"),


### PR DESCRIPTION
Added entries for Index of Nearest and Simulation Zone for the Geometry Nodes Editor.

The current implementation for Simulation Zone is kinda hacky as the concept of a _'zone'_ made out of multiple nodes does not fit with the NodeItem abstraction that the rest of the addon relies on.

Right now, this patch just sidesteps that by injecting the Simulation Zone entry and catching it as an exception. Though as more zones might get introduced in later Blender updates _(e.g, Serial Loops, etc.)_, maybe a way to generally handle both nodes and zones would be worth implementing.